### PR TITLE
Solved installation error and error that arises in example.ipynb

### DIFF
--- a/src/isodisreg/isocdf_seq.cpp
+++ b/src/isodisreg/isocdf_seq.cpp
@@ -260,8 +260,11 @@ py::array_t<double> pavaCorrect_c(py::array_t<double, py::array::c_style> y) {
     auto out_shape = out_buf.shape;
     auto out_strides = out_buf.strides;
 
-    double weight[m];
-    int index[m];
+    //double weight[m]; this throws an error, changed to the following
+    std::vector<double> weight(m);
+    //int index[m]; this throws an error, changed to the following
+    std::vector<int> index(m);
+
     int ci = 0, j = 0;
     double nw;
 

--- a/src/isodisreg/modeling_evaluation.py
+++ b/src/isodisreg/modeling_evaluation.py
@@ -639,9 +639,10 @@ def idr (y, X, groups = None, orders = dict({"1":"comp"}), verbose = False, max_
         i = 0
         I = nThr -1
         #conv =  np.full(I, False, dtype=bool) 
-        q = -weights*np.array(cpY.apply(lambda x: np.mean(np.array(x) <= thresholds[i]))) 
+        q = -weights*np.array(cpY.apply(lambda x: np.mean(np.array(x) <= thresholds[i])))
+	u = np.ones(nConstr)
         m = osqp.OSQP()
-        m.setup(P=P, q=q, A=A, l=l, verbose = verbose, max_iter = max_iter, eps_rel = eps_rel, eps_abs = eps_abs) 
+        m.setup(P=P, q=q, A=A, l=l, u=u, verbose = verbose, max_iter = max_iter, eps_rel = eps_rel, eps_abs = eps_abs) 
         sol = m.solve()
         pmax = np.where(sol.x>0,sol.x,0)
         cdf[:,0] = np.where(pmax<1, pmax, 1) 


### PR DESCRIPTION
Added a variable "u" in the idr function after initializing m = osqp.OSQP().
changed the variable assignment in the isocdf_seq.cpp file, otherwise, this caused an error during installation.